### PR TITLE
Fix link text on Start page

### DIFF
--- a/app/views/sp4v1_start_veteran_verify.html
+++ b/app/views/sp4v1_start_veteran_verify.html
@@ -32,11 +32,9 @@ Prototype Kit {% endblock %} {% block header %}
     </p>
       
        
-     <p>For more information about the help and benefits veterans are eligible for in the UK visit:<br> <a
-              href="https://www.gov.uk/topic/defence-armed-forces/support-services-veterans-families"
+     <p><a href="https://www.gov.uk/topic/defence-armed-forces/support-services-veterans-families"
               target="_new" rel="noreferrer noopener"
-            >
-              Support services for veterans and their families</a></p>
+            >View help and benefits for veterans in the UK</a></p>
 
     <h2 class="govuk-heading-m">What you need to apply</h2>
 


### PR DESCRIPTION
Links should be calls to action, not the title of the target page