### PR TITLE
Put user object in session and ensure persistence

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -153,6 +153,7 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
 
   router.use((req, res, next) => {
     if (req.session.passport) {
+      // For Nunjucks convenience
       res.locals.user = req.session.passport.user
     }
     next()
@@ -212,30 +213,6 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
     }
   })
 
-  // router.post('/question_email_address_input', function (req, res) {
-  //   const email = req.session.data.question_email_address
-  //   const previousApplicationEmail = req.session.data.previous_application_email
-
-  //   if (!email) {
-  //     const error = { text: 'Enter your email address' }
-  //     return res.render('question_email_address', { error })
-  //   }
-
-  //   if (
-  //     email &&
-  //     validator.isEmail(email) &&
-  //     previousApplicationEmail.toString() === email
-  //   ) {
-  //     res.redirect('/govuk_previous_application_email')
-  //   }
-
-  //   if (email && validator.isEmail(email)) {
-  //     res.redirect('/govuk_create_check_email')
-  //   } else {
-  //     const error = { text: 'Enter a valid email address' }
-  //     return res.render('question_email_address', { error })
-  //   }
-  // })
 
   router.all('/question_name_from_identity_claim', function (req, res) {
 
@@ -257,13 +234,6 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
     // Set up session storage for current name
     // This will be printed on the card
     req.session.data.current_DI_name = distinctClaimNames[0]
-
-    // const previousNames = getPreviousNames(distinctClaimNames)
-    // req.session.data.previous_DI_names = previousNames
-
-    // previousNames.forEach((name, index) => {
-    //   req.session.data[`previous_DI_name_${index + 1}`] = name
-    // })
 
     res.render('question_name_from_identity_claim' )
   })
@@ -307,23 +277,6 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
     if (firstName && lastName) {
       req.session.data.name_at_discharge = `${firstName} ${lastName}`
       res.redirect('/certificate_upload')
-    }
-  })
-
-  router.post('/govuk_account_sign_in_input', function (req, res) {
-    const email = req.session.data.question_email_address
-
-    if (!email) {
-      const error = { text: 'Enter the email address you registered on GOV.UK' }
-      return res.render('govuk_account_sign_in', { error })
-    }
-
-    if (email && validator.isEmail(email)) {
-      req.session.data.question_email_address = email
-      res.redirect('/govuk_account_password')
-    } else {
-      const error = { text: 'Enter a valid email address' }
-      return res.render('govuk_account_sign_in', { error })
     }
   })
 
@@ -491,13 +444,6 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
   })
 
   router.post('/upload_photo', function (req, res) {
-    // const answer = req.body.uploaded_user_photo
-
-    // if (!answer) {
-    //   const error = { text: "You must upload a valid photo" }
-    //   return res.render('upload_photo', { error })
-    // }
-
     res.redirect('/question_address_to_send_to')
   })
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -141,12 +141,8 @@ router.post('/start_veteran_apply_choice', function (req, res) {
   const answer = req.session.data.start_veteran_match_status
 
   if (!answer) {
-    const error = { text: "Select 'happy path', 'unhappy path' or 'Test GOV.UK Sign In IPV'" }
+    const error = { text: "Select 'Test GOV.UK Sign In IPV' or 'Skip straight to matching" }
     return res.render('index', { error })
-  }
-
-  if (answer === 'Fail') {
-    req.session.data.set_unhappy_path = true
   }
 
   if (answer === 'IPV') {
@@ -209,7 +205,7 @@ router.post('/eligibility_two', function (req, res) {
         req.session.data[`previous_DI_name_${index + 1}`] = name
       })
 
-      res.redirect('/govuk_create_or_sign_in')
+      res.redirect('/question_name_from_identity_claim')
     }
   }
 })

--- a/app/routes.js
+++ b/app/routes.js
@@ -110,8 +110,36 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
     })
   )
 
+  const LocalStrategy = require('passport-local');
+
+  passport.use(new LocalStrategy(
+    // Fake userdata when we skip IPV
+    function(username, password, done) {
+      userinfo = {
+        sub: "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=",
+        email: "sandy@example.com",
+        email_verified: true,
+        phone_number: "+447700900451",
+        phone_number_verified: true,
+      }
+      userinfo.core_identity = getFakeDIClaimResponse('1975')
+      //console.log(userinfo)
+      return done(null, userinfo);
+    })
+  )
+
   router.get('/login', (req, res, next) => {
-    passport.authenticate('oidc')(req, res, next)
+    if (req.session.data.test_ipv === true) {
+      // Redirect to GOV.UK Sign In with IPV
+      passport.authenticate('oidc')(req, res, next)
+    } else {
+      req.body.username = 'sandy'
+      req.body.password = 'foo'
+      passport.authenticate('local', {
+        successRedirect: '/profile',
+        failureMessage: true
+      })(req, res, next)
+    }
   })
 
   router.get('/callback', (req, res, next) => {
@@ -124,7 +152,9 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
   })
 
   router.use((req, res, next) => {
-    req.session.user = req.user
+    if (req.session.passport) {
+      res.locals.user = req.session.passport.user
+    }
     next()
   })
 
@@ -135,658 +165,658 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
   passport.deserializeUser(function (obj, cb) {
     cb(null, obj)
   })
-})
 
-router.post('/start_veteran_apply_choice', function (req, res) {
-  const answer = req.session.data.start_veteran_match_status
 
-  if (!answer) {
-    const error = { text: "Select 'Test GOV.UK Sign In IPV' or 'Skip straight to matching" }
-    return res.render('index', { error })
-  }
+  router.post('/start_veteran_apply_choice', function (req, res) {
+    const answer = req.session.data.start_veteran_match_status
 
-  if (answer === 'IPV') {
-    req.session.data.test_ipv = true
-  }
+    if (!answer) {
+      const error = { text: "Select 'Test GOV.UK Sign In IPV' or 'Skip straight to matching" }
+      return res.render('index', { error })
+    }
 
-  res.redirect('/start_veteran_apply')
-})
+    if (answer === 'IPV') {
+      req.session.data.test_ipv = true
+    }
 
-router.post('/eligibility_one', function (req, res) {
-  const formermember = req.body['former-member']
+    res.redirect('/start_veteran_apply')
+  })
 
-  if (!formermember) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('eligibility_one', { error }) // relative URL, for reasons unknown
-  }
+  router.post('/eligibility_one', function (req, res) {
+    const formermember = req.body['former-member']
 
-  if (formermember === 'no') {
-    res.redirect('/ineligible')
-  } else {
-    res.redirect('/eligibility_two')
-  }
-})
+    if (!formermember) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('eligibility_one', { error }) // relative URL, for reasons unknown
+    }
 
-router.post('/eligibility_two', function (req, res) {
-  const ukresident = req.body['uk-resident']
-
-  if (!ukresident) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('eligibility_two', { error })
-  }
-
-  if (ukresident === 'no') {
-    res.redirect('/ineligible_non_resident')
-  } else {
-
-    if (req.session.data.test_ipv === true) {
-      res.redirect('/login')
+    if (formermember === 'no') {
+      res.redirect('/ineligible')
     } else {
-      if (typeof req.session.user === 'undefined') {
-        // We need a faked-up set of claims, because we skipped IPV
-        req.session.user = {
-          sub: "urn:fdc:gov.uk:2022:56P4CMsGh_02YOlWpd8PAOI-2sVlB2nsNU7mcLZYhYw=",
-          email: "sandy@example.com",
-          email_verified: true,
-          phone_number: "+447700900451",
-          phone_number_verified: true,
-        }
-        req.session.user.core_identity = getFakeDIClaimResponse('1975')
+      res.redirect('/eligibility_two')
+    }
+  })
+
+  router.post('/eligibility_two', function (req, res) {
+    const ukresident = req.body['uk-resident']
+
+    if (!ukresident) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('eligibility_two', { error })
+    }
+
+    if (ukresident === 'no') {
+      res.redirect('/ineligible_non_resident')
+    } else {
+      res.redirect('/login')
+    }
+  })
+
+  // router.post('/question_email_address_input', function (req, res) {
+  //   const email = req.session.data.question_email_address
+  //   const previousApplicationEmail = req.session.data.previous_application_email
+
+  //   if (!email) {
+  //     const error = { text: 'Enter your email address' }
+  //     return res.render('question_email_address', { error })
+  //   }
+
+  //   if (
+  //     email &&
+  //     validator.isEmail(email) &&
+  //     previousApplicationEmail.toString() === email
+  //   ) {
+  //     res.redirect('/govuk_previous_application_email')
+  //   }
+
+  //   if (email && validator.isEmail(email)) {
+  //     res.redirect('/govuk_create_check_email')
+  //   } else {
+  //     const error = { text: 'Enter a valid email address' }
+  //     return res.render('question_email_address', { error })
+  //   }
+  // })
+
+  router.all('/question_name_from_identity_claim', function (req, res) {
+
+    // Identity claim set up
+    const distinctClaimNames = getClaimNames(res.locals.user.core_identity) // All the names
+
+    // Populate an array of objects for use in the Radio Button group
+    res.locals.DI_names = []
+    distinctClaimNames.forEach((fullname, i) => {
+      res.locals.DI_names[i] = {
+        value : fullname,
+        text : fullname
       }
-      // Identity claim set up
-      const distinctClaimNames = getClaimNames(req.session.user.core_identity) // All the names
+    })
 
-      // Set up session storage for current & previous names
-      req.session.data.current_DI_name = distinctClaimNames[0]
-      const previousNames = getPreviousNames(distinctClaimNames)
-      req.session.data.previous_DI_names = previousNames
+    res.locals.DI_names.push( { divider: "or" } )
+    res.locals.DI_names.push( { value: "service_name_other", text: "I had a different name" } )
 
-      previousNames.forEach((name, index) => {
-        req.session.data[`previous_DI_name_${index + 1}`] = name
-      })
+    // Set up session storage for current & previous names
+    // req.session.data.current_DI_name = distinctClaimNames[0]
 
-      res.redirect('/question_name_from_identity_claim')
+    // const previousNames = getPreviousNames(distinctClaimNames)
+    // req.session.data.previous_DI_names = previousNames
+
+    // previousNames.forEach((name, index) => {
+    //   req.session.data[`previous_DI_name_${index + 1}`] = name
+    // })
+
+    res.render('question_name_from_identity_claim' )
+  })
+
+  router.all('/question_name_from_identity_claim_choice', function (req, res) {
+    const nameChoice = req.session.data.name_at_discharge
+
+    if (!nameChoice) {
+      const error = { text: "Select the name you used when you left the Armed Forces" }
+      return res.render('question_name_from_identity_claim', { error })
     }
-  }
-})
 
-// router.post('/question_email_address_input', function (req, res) {
-//   const email = req.session.data.question_email_address
-//   const previousApplicationEmail = req.session.data.previous_application_email
+    diNames = getClaimNames(res.locals.user.core_identity)
 
-//   if (!email) {
-//     const error = { text: 'Enter your email address' }
-//     return res.render('question_email_address', { error })
-//   }
-
-//   if (
-//     email &&
-//     validator.isEmail(email) &&
-//     previousApplicationEmail.toString() === email
-//   ) {
-//     res.redirect('/govuk_previous_application_email')
-//   }
-
-//   if (email && validator.isEmail(email)) {
-//     res.redirect('/govuk_create_check_email')
-//   } else {
-//     const error = { text: 'Enter a valid email address' }
-//     return res.render('question_email_address', { error })
-//   }
-// })
-
-router.post('/question_name_from_identity_claim_choice', function (req, res) {
-  const nameChoice = req.session.data.name_at_discharge
-
-  if (!nameChoice) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_name_from_identity_claim', { error })
-  }
-
-  if (nameChoice === 'Yes') {
-    req.session.data.name_at_discharge = req.session.data.current_DI_name
-
-    if (req.session.data.set_unhappy_path !== true) {
+    if (diNames.indexOf(nameChoice) === -1) {
+      // The name supplied is not one of the ones we received from IPV
+      // so we will need to get a copy of their name change documentation
+      req.session.data.set_unhappy_path = true
+      req.session.data.start_veteran_match_status = 'Fail'
+      res.redirect('/question_name_at_discharge')
+    } else {
       req.session.data.start_veteran_match_status = 'Success'
+      res.redirect('/question_service_number')
     }
-    res.redirect('/question_service_number')
-  }
+  })
 
-  if (nameChoice === 'No') {
-    // Matching set to fail - manual check required
-    req.session.data.start_veteran_match_status = 'Fail'
-    res.redirect('/question_name_at_discharge')
-  }
-})
+  router.post('/question_name_at_discharge_input', function (req, res) {
+    const firstName = req.session.data.first_name_at_discharge
+    const lastName = req.session.data.last_name_at_discharge
 
-router.post('/question_name_at_discharge_input', function (req, res) {
-  const firstName = req.session.data.first_name_at_discharge
-  const lastName = req.session.data.last_name_at_discharge
-
-  if (!firstName) {
-    const firstNameError = { text: 'Enter your first name' }
-    return res.render('question_name_at_discharge', { firstNameError })
-  }
-
-  if (!lastName) {
-    const lastNameError = { text: 'Enter your last name' }
-    return res.render('question_name_at_discharge', { lastNameError })
-  }
-
-  if (firstName && lastName) {
-    req.session.data.name_at_discharge = `${firstName} ${lastName}`
-    res.redirect('/certificate_upload')
-  }
-})
-
-router.post('/govuk_account_sign_in_input', function (req, res) {
-  const email = req.session.data.question_email_address
-
-  if (!email) {
-    const error = { text: 'Enter the email address you registered on GOV.UK' }
-    return res.render('govuk_account_sign_in', { error })
-  }
-
-  if (email && validator.isEmail(email)) {
-    req.session.data.question_email_address = email
-    res.redirect('/govuk_account_password')
-  } else {
-    const error = { text: 'Enter a valid email address' }
-    return res.render('govuk_account_sign_in', { error })
-  }
-})
-
-router.post('/govuk_account_password_input', function (req, res) {
-  const answer = req.session.data.govuk_password
-
-  if (!answer) {
-    const error = { text: 'Enter the password you registered on GOV.UK' }
-    return res.render('govuk_account_password', { error })
-  }
-
-  if (answer) {
-    res.redirect('/govuk_account_sign_in_confirmed_copy')
-  }
-})
-
-router.post('/govuk_create_check_email_code', function (req, res) {
-  const answer = req.session.data.govuk_email_code
-
-  if (!answer) {
-    const error = { text: 'Enter the 6 digit code sent to you' }
-    return res.render('govuk_create_check_email', { error })
-  }
-
-  if (answer) {
-    res.redirect('/govuk_account_sign_in_confirmed')
-  }
-})
-
-router.post('/certificate_upload_choice', function (req, res) {
-  const answer = req.session.data.certificate_upload_further_documents
-
-  if (!answer) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('certificate_upload_radio', { error })
-  }
-
-  if (answer === 'yes') {
-    res.redirect('/certificate_upload_extra')
-  }
-
-  if (answer === 'no') {
-    res.redirect('/question_service_number')
-  }
-})
-
-router.post('/question_service_number_input', function (req, res) {
-  const answer = req.session.data.question_service_number
-
-  if (!answer) {
-    const error = { text: 'Enter your service number' }
-    return res.render('question_service_number', { error })
-  }
-
-  if (answer && answer.length >= 4 && answer.length <= 15) {
-    res.redirect('/question_enlistment_date')
-  } else {
-    const error = {
-      text: 'Enter a valid service number of 4 to 15 characters'
+    if (!firstName) {
+      const firstNameError = { text: 'Enter your first name' }
+      return res.render('question_name_at_discharge', { firstNameError })
     }
-    return res.render('question_service_number', { error })
-  }
-})
 
-router.post('/question_choice_enlistment_date', function (req, res) {
-  const enlistmentYear = req.session.data['enlistment-year-year']
-  const dischargeYear = req.session.data['discharge-year-year']
-
-  if (!enlistmentYear) {
-    const error = { text: 'Enter a value for the year' }
-    return res.render('question_enlistment_date', { error })
-  }
-
-  if (
-    dischargeYear &&
-    enlistmentYear &&
-    validator.isBefore(dischargeYear, enlistmentYear)
-  ) {
-    const error = { text: 'Enlistment year can not be before discharge year' }
-    return res.render('question_enlistment_date', { error })
-  }
-
-  if (
-    enlistmentYear &&
-    validator.isAfter(enlistmentYear, '1939') &&
-    validator.isBefore(enlistmentYear)
-  ) {
-    res.redirect('/question_discharge_date')
-  } else {
-    const error = { text: 'Enter a valid year' }
-    return res.render('question_enlistment_date', { error })
-  }
-})
-
-router.post('/question_choice_discharge_date', function (req, res) {
-  const dischargeYear = req.session.data['discharge-year-year']
-  const enlistmentYear = req.session.data['enlistment-year-year']
-
-  if (!dischargeYear) {
-    const error = { text: 'Enter a value for the year' }
-    return res.render('question_discharge_date', { error })
-  }
-
-  if (
-    dischargeYear &&
-    validator.isBefore(dischargeYear) && // is before today
-    validator.isAfter(dischargeYear, '1939') &&
-    (validator.isAfter(dischargeYear, enlistmentYear) ||
-      dischargeYear === enlistmentYear)
-  ) {
-    res.redirect('/question_national_insurance')
-  } else {
-    const error = { text: 'Enter a valid year' }
-    return res.render('question_discharge_date', { error })
-  }
-})
-
-router.post('/question_national_insurance_input', function (req, res) {
-  let answer = req.session.data.national_insurance_number
-  const regexUse = new RegExp(process.env.NIN_REGEX)
-
-  if (!answer) {
-    const error = { text: 'Enter your national insurance number' }
-    return res.render('question_national_insurance', { error })
-  }
-
-  if (answer) {
-    answer = answer.replace(/ /g, '')
-  }
-
-  if (answer === 'QQ123456C' || (answer && regexUse.test(answer))) {
-    res.redirect('/question_served_with')
-  } else {
-    const error = {
-      text: 'Enter a National Insurance number in the correct format'
+    if (!lastName) {
+      const lastNameError = { text: 'Enter your last name' }
+      return res.render('question_name_at_discharge', { lastNameError })
     }
-    return res.render('question_national_insurance', { error })
-  }
-})
 
-router.post('/question_served_with', function (req, res) {
-  const answer = req.body['branch-served-with']
-
-  if (!answer) {
-    const error = { text: 'Select an option' }
-    return res.render('question_served_with', { error })
-  }
-
-  if (answer) {
-    res.redirect('/question_id_type')
-  }
-})
-
-router.post('/question_id_route', function (req, res) {
-  const answer = req.body.id_choice
-
-  if (!answer) {
-    const error = { text: 'Choose your preferred card format' }
-    return res.render('question_id_type', { error })
-  }
-
-  if (answer) {
-    res.redirect('/upload_photo')
-  }
-})
-
-router.post('/upload_photo', function (req, res) {
-  // const answer = req.body.uploaded_user_photo
-
-  // if (!answer) {
-  //   const error = { text: "You must upload a valid photo" }
-  //   return res.render('upload_photo', { error })
-  // }
-
-  res.redirect('/question_address_to_send_to')
-})
-
-router.post('/question_address_to_send_to_choice', function (req, res) {
-  const postalAddressChoice = req.body.postal_address_choice
-
-  if (!postalAddressChoice) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_address_to_send_to', { error })
-  }
-
-  if (postalAddressChoice === 'Yes') {
-    res.redirect('/question_vetcard_comms')
-  }
-
-  if (postalAddressChoice === 'No') {
-    res.redirect('/question_address')
-  }
-})
-
-router.post('/question_address_input', function (req, res) {
-  const addressHouseFlatNumber = req.body.address_house_flat_number
-  const addressLine1 = req.body.address_line_1
-  const addressTownCity = req.body.address_town_city
-  let addressPostcode = req.body.address_postcode
-
-  if (!addressHouseFlatNumber) {
-    const errorHome = { text: 'Enter the number of your home' }
-    return res.render('question_address', { errorHome })
-  }
-
-  if (!addressLine1) {
-    const errorAddress = { text: 'Enter your address' }
-    return res.render('question_address', { errorAddress })
-  }
-
-  if (!addressTownCity) {
-    const errorTownCity = { text: 'Enter the town or city you live in' }
-    return res.render('question_address', { errorTownCity })
-  }
-
-  if (!addressPostcode || regexUkPostcode(addressPostcode) === false) {
-    const errorPostcode = { text: 'Enter a valid postcode' }
-    return res.render('question_address', { errorPostcode })
-  }
-
-  if (
-    (addressHouseFlatNumber, addressLine1, addressTownCity, addressPostcode)
-  ) {
-    addressPostcode = removeStringWhiteSpace(addressPostcode)
-    req.session.data.postal_address = `${addressHouseFlatNumber}, ${addressLine1}, ${addressTownCity}, ${addressPostcode}`
-    res.redirect('/question_vetcard_comms')
-  }
-})
-
-router.post('/question_vetcard_comms', function (req, res) {
-  const answer = req.body.question_comms_choice
-
-  if (!answer) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_vetcard_comms', { error })
-  }
-
-  if (answer === 'Yes') {
-    res.redirect('/vetcard_communications_preference')
-  }
-
-  if (answer === 'No') {
-    req.session.data.comms_preference_email_address =
-      req.session.data.question_email_address
-
-    req.session.data.comms_preference_phone_number = removeStringWhiteSpace(
-      req.session.data.phone_number.toString()
-    )
-
-    res.redirect('/vetcard_account_summary_extra')
-  }
-})
-
-router.post('/vetcard_communications_preference_choice', function (req, res) {
-  const answer = req.body.communications_choice
-  req.session.data.comms_preference_email_sms = false
-
-  if (answer === '_unchecked') {
-    const error = { text: 'Select at least one option' }
-    return res.render('vetcard_communications_preference', { error })
-  }
-  answer.shift()
-
-  if (answer.length === 1 && answer.includes('Email')) {
-    res.redirect('/question_email_to_send_to')
-  }
-
-  if (answer.length === 1 && answer.includes('Text message')) {
-    res.redirect('/question_phone_number_to_send_to')
-  }
-
-  if (answer) {
-    req.session.data.comms_preference_email_sms = true
-    res.redirect('/question_email_to_send_to_duo')
-  }
-})
-
-router.post('/question_email_to_send_to_choice', function (req, res) {
-  const emailChoice = req.body.email_choice
-  const emailAndSms = req.session.data.comms_preference_email_sms
-
-  if (!emailChoice && emailAndSms) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_email_to_send_to_duo', { error })
-  }
-
-  if (!emailChoice) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_email_to_send_to', { error })
-  }
-
-  if (emailChoice === 'No' && emailAndSms) {
-    res.redirect('/question_email_update_duo')
-  }
-
-  if (emailChoice === 'Yes' && emailAndSms) {
-    req.session.data.comms_preference_email_address =
-      req.session.data.question_email_address
-    res.redirect('/question_phone_number_to_send_to_duo')
-  }
-
-  if (emailChoice === 'Yes') {
-    req.session.data.comms_preference_email_address =
-      req.session.data.question_email_address
-    res.redirect('/vetcard_account_summary_extra')
-  }
-
-  if (emailChoice === 'No') {
-    res.redirect('/question_email_update')
-  }
-})
-
-router.post('/question_email_update_input', function (req, res) {
-  const emailUpdate = req.body.question_email_address_update
-  const emailAndSms = req.session.data.comms_preference_email_sms
-
-  if (!emailUpdate && emailAndSms) {
-    const errorDuo = { text: 'Enter a valid email address' }
-    return res.render('question_email_update_duo', { errorDuo })
-  }
-
-  if (!emailUpdate) {
-    const error = { text: 'Enter a valid email address' }
-    return res.render('question_email_update', { error })
-  }
-
-  if (emailUpdate && validator.isEmail(emailUpdate) && emailAndSms) {
-    req.session.data.comms_preference_email_address = emailUpdate
-    res.redirect('/question_phone_number_to_send_to_duo')
-  }
-
-  if (emailUpdate && validator.isEmail(emailUpdate)) {
-    req.session.data.comms_preference_email_address = emailUpdate
-    res.redirect('/vetcard_account_summary_extra')
-  } else {
-    const error = { text: 'Enter a valid email address' }
-    return res.render('question_email_update', { error })
-  }
-})
-
-router.post('/question_phone_number_to_send_to_choice', function (req, res) {
-  const phoneNumberChoice = req.body.phone_number_choice
-  const emailAndSms = req.session.data.comms_preference_email_sms
-
-  if (!phoneNumberChoice && emailAndSms) {
-    const errorDuo = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_phone_number_to_send_to_duo', { errorDuo })
-  }
-
-  if (!phoneNumberChoice) {
-    const error = { text: "Select 'Yes' or 'No'" }
-    return res.render('question_phone_number_to_send_to', { error })
-  }
-  if (phoneNumberChoice === 'No' && emailAndSms) {
-    res.redirect('/question_phone_number_update_duo')
-  }
-
-  if (phoneNumberChoice === 'Yes') {
-    req.session.data.comms_preference_phone_number = removeStringWhiteSpace(
-      req.session.data.phone_number.toString()
-    )
-    res.redirect('/vetcard_account_summary_extra')
-  }
-
-  if (phoneNumberChoice === 'No') {
-    res.redirect('/question_phone_number_update')
-  }
-})
-
-router.post('/question_phone_number_update_input', function (req, res) {
-  const phoneNumberUpdate = req.body.question_phone_number_update
-  const emailAndSms = req.session.data.comms_preference_email_sms
-
-  if (!phoneNumberUpdate && emailAndSms) {
-    console.log('error check 1')
-    const errorDuo = {
-      text: 'Enter a valid UK mobile number, like 077 456 78901'
+    if (firstName && lastName) {
+      req.session.data.name_at_discharge = `${firstName} ${lastName}`
+      res.redirect('/certificate_upload')
     }
-    return res.render('question_phone_number_update_duo', { errorDuo })
-  }
+  })
 
-  if (!phoneNumberUpdate && !emailAndSms) {
-    console.log('error check 2')
-    const error = {
-      text: 'Enter a valid UK mobile number, like 077 456 78901'
+  router.post('/govuk_account_sign_in_input', function (req, res) {
+    const email = req.session.data.question_email_address
+
+    if (!email) {
+      const error = { text: 'Enter the email address you registered on GOV.UK' }
+      return res.render('govuk_account_sign_in', { error })
     }
-    return res.render('question_phone_number_update', { error })
-  }
 
-  if (phoneNumberUpdate && regexUkMobileNumber(phoneNumberUpdate)) {
-    req.session.data.comms_preference_phone_number =
-      removeStringWhiteSpace(phoneNumberUpdate)
-    res.redirect('/vetcard_account_summary_extra')
-  } else {
-    console.log('error check 3')
-    const error = {
-      text: 'Enter a valid UK mobile number, like 077 456 78901'
+    if (email && validator.isEmail(email)) {
+      req.session.data.question_email_address = email
+      res.redirect('/govuk_account_password')
+    } else {
+      const error = { text: 'Enter a valid email address' }
+      return res.render('govuk_account_sign_in', { error })
     }
-    return res.render('question_phone_number_update', { error })
-  }
-})
+  })
 
-router.post('/vetcard_account_summary_choice', function (req, res) {
-  let idChoice = req.session.data.id_choice
-  const fullName = req.session.data.full_name
-  const postalAddress = req.session.data.postal_address
-  const emailAddress = req.session.data.comms_preference_email_address
-  const serviceNumber = req.session.data.question_service_number
+  router.post('/govuk_account_password_input', function (req, res) {
+    const answer = req.session.data.govuk_password
 
-  const matchStatus = req.session.data.start_veteran_match_status
+    if (!answer) {
+      const error = { text: 'Enter the password you registered on GOV.UK' }
+      return res.render('govuk_account_password', { error })
+    }
 
-  const personalisation = {
-    full_name: fullName.toString(),
-    postal_address: postalAddress.toString(),
-    submission_reference: 'HDJ2123F',
-    service_number: serviceNumber.toString()
-  }
+    if (answer) {
+      res.redirect('/govuk_account_sign_in_confirmed_copy')
+    }
+  })
 
-  if (!idChoice) {
-    idChoice = 'Physical card'
-  }
+  router.post('/govuk_create_check_email_code', function (req, res) {
+    const answer = req.session.data.govuk_email_code
 
-  if (matchStatus === 'Fail') {
-    notify
-      .sendEmail(
-        process.env.TEST_EMAIL_UNHAPPY_PATH_TEMPLATE,
-        // `emailAddress` here needs to match the name of the form field in
-        // your HTML page
-        emailAddress.toString(),
-        {
-          personalisation,
-          reference: uuidv4()
-        }
+    if (!answer) {
+      const error = { text: 'Enter the 6 digit code sent to you' }
+      return res.render('govuk_create_check_email', { error })
+    }
+
+    if (answer) {
+      res.redirect('/govuk_account_sign_in_confirmed')
+    }
+  })
+
+  router.post('/certificate_upload_choice', function (req, res) {
+    const answer = req.session.data.certificate_upload_further_documents
+
+    if (!answer) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('certificate_upload_radio', { error })
+    }
+
+    if (answer === 'yes') {
+      res.redirect('/certificate_upload_extra')
+    }
+
+    if (answer === 'no') {
+      res.redirect('/question_service_number')
+    }
+  })
+
+  router.post('/question_service_number_input', function (req, res) {
+    const answer = req.session.data.question_service_number
+
+    if (!answer) {
+      const error = { text: 'Enter your service number' }
+      return res.render('question_service_number', { error })
+    }
+
+    if (answer && answer.length >= 4 && answer.length <= 15) {
+      res.redirect('/question_enlistment_date')
+    } else {
+      const error = {
+        text: 'Enter a valid service number of 4 to 15 characters'
+      }
+      return res.render('question_service_number', { error })
+    }
+  })
+
+  router.post('/question_choice_enlistment_date', function (req, res) {
+    const enlistmentYear = req.session.data['enlistment-year-year']
+    const dischargeYear = req.session.data['discharge-year-year']
+
+    if (!enlistmentYear) {
+      const error = { text: 'Enter a value for the year' }
+      return res.render('question_enlistment_date', { error })
+    }
+
+    if (
+      dischargeYear &&
+      enlistmentYear &&
+      validator.isBefore(dischargeYear, enlistmentYear)
+    ) {
+      const error = { text: 'Enlistment year can not be before discharge year' }
+      return res.render('question_enlistment_date', { error })
+    }
+
+    if (
+      enlistmentYear &&
+      validator.isAfter(enlistmentYear, '1939') &&
+      validator.isBefore(enlistmentYear)
+    ) {
+      res.redirect('/question_discharge_date')
+    } else {
+      const error = { text: 'Enter a valid year' }
+      return res.render('question_enlistment_date', { error })
+    }
+  })
+
+  router.post('/question_choice_discharge_date', function (req, res) {
+    const dischargeYear = req.session.data['discharge-year-year']
+    const enlistmentYear = req.session.data['enlistment-year-year']
+
+    if (!dischargeYear) {
+      const error = { text: 'Enter a value for the year' }
+      return res.render('question_discharge_date', { error })
+    }
+
+    if (
+      dischargeYear &&
+      validator.isBefore(dischargeYear) && // is before today
+      validator.isAfter(dischargeYear, '1939') &&
+      (validator.isAfter(dischargeYear, enlistmentYear) ||
+        dischargeYear === enlistmentYear)
+    ) {
+      res.redirect('/question_national_insurance')
+    } else {
+      const error = { text: 'Enter a valid year' }
+      return res.render('question_discharge_date', { error })
+    }
+  })
+
+  router.post('/question_national_insurance_input', function (req, res) {
+    let answer = req.session.data.national_insurance_number
+    const regexUse = new RegExp(process.env.NIN_REGEX)
+
+    if (!answer) {
+      const error = { text: 'Enter your national insurance number' }
+      return res.render('question_national_insurance', { error })
+    }
+
+    if (answer) {
+      answer = answer.replace(/ /g, '')
+    }
+
+    if (answer === 'QQ123456C' || (answer && regexUse.test(answer))) {
+      res.redirect('/question_served_with')
+    } else {
+      const error = {
+        text: 'Enter a National Insurance number in the correct format'
+      }
+      return res.render('question_national_insurance', { error })
+    }
+  })
+
+  router.post('/question_served_with', function (req, res) {
+    const answer = req.body['branch-served-with']
+
+    if (!answer) {
+      const error = { text: 'Select an option' }
+      return res.render('question_served_with', { error })
+    }
+
+    if (answer) {
+      res.redirect('/question_id_type')
+    }
+  })
+
+  router.post('/question_id_route', function (req, res) {
+    const answer = req.body.id_choice
+
+    if (!answer) {
+      const error = { text: 'Choose your preferred card format' }
+      return res.render('question_id_type', { error })
+    }
+
+    if (answer) {
+      res.redirect('/upload_photo')
+    }
+  })
+
+  router.post('/upload_photo', function (req, res) {
+    // const answer = req.body.uploaded_user_photo
+
+    // if (!answer) {
+    //   const error = { text: "You must upload a valid photo" }
+    //   return res.render('upload_photo', { error })
+    // }
+
+    res.redirect('/question_address_to_send_to')
+  })
+
+  router.post('/question_address_to_send_to_choice', function (req, res) {
+    const postalAddressChoice = req.body.postal_address_choice
+
+    if (!postalAddressChoice) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('question_address_to_send_to', { error })
+    }
+
+    if (postalAddressChoice === 'Yes') {
+      res.redirect('/question_vetcard_comms')
+    }
+
+    if (postalAddressChoice === 'No') {
+      res.redirect('/question_address')
+    }
+  })
+
+  router.post('/question_address_input', function (req, res) {
+    const addressHouseFlatNumber = req.body.address_house_flat_number
+    const addressLine1 = req.body.address_line_1
+    const addressTownCity = req.body.address_town_city
+    let addressPostcode = req.body.address_postcode
+
+    if (!addressHouseFlatNumber) {
+      const errorHome = { text: 'Enter the number of your home' }
+      return res.render('question_address', { errorHome })
+    }
+
+    if (!addressLine1) {
+      const errorAddress = { text: 'Enter your address' }
+      return res.render('question_address', { errorAddress })
+    }
+
+    if (!addressTownCity) {
+      const errorTownCity = { text: 'Enter the town or city you live in' }
+      return res.render('question_address', { errorTownCity })
+    }
+
+    if (!addressPostcode || regexUkPostcode(addressPostcode) === false) {
+      const errorPostcode = { text: 'Enter a valid postcode' }
+      return res.render('question_address', { errorPostcode })
+    }
+
+    if (
+      (addressHouseFlatNumber, addressLine1, addressTownCity, addressPostcode)
+    ) {
+      addressPostcode = removeStringWhiteSpace(addressPostcode)
+      req.session.data.postal_address = `${addressHouseFlatNumber}, ${addressLine1}, ${addressTownCity}, ${addressPostcode}`
+      res.redirect('/question_vetcard_comms')
+    }
+  })
+
+  router.post('/question_vetcard_comms', function (req, res) {
+    const answer = req.body.question_comms_choice
+
+    if (!answer) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('question_vetcard_comms', { error })
+    }
+
+    if (answer === 'Yes') {
+      res.redirect('/vetcard_communications_preference')
+    }
+
+    if (answer === 'No') {
+      req.session.data.comms_preference_email_address =
+        req.session.data.question_email_address
+
+      req.session.data.comms_preference_phone_number = removeStringWhiteSpace(
+        req.session.data.phone_number.toString()
       )
-      .then((response) => console.log(response))
-      .catch((err) => console.error(err.response.data))
 
-    res.redirect('/vetcard_match_fail_explanation')
-    return false
-  }
+      res.redirect('/vetcard_account_summary_extra')
+    }
+  })
 
-  if (idChoice === 'Physical card') {
-    notify
-      .sendEmail(
-        process.env.TEST_EMAIL_CARD_ONLY_TEMPLATE,
-        // `emailAddress` here needs to match the name of the form field in
-        // your HTML page
-        emailAddress.toString(),
-        {
-          personalisation,
-          reference: uuidv4()
-        }
+  router.post('/vetcard_communications_preference_choice', function (req, res) {
+    const answer = req.body.communications_choice
+    req.session.data.comms_preference_email_sms = false
+
+    if (answer === '_unchecked') {
+      const error = { text: 'Select at least one option' }
+      return res.render('vetcard_communications_preference', { error })
+    }
+    answer.shift()
+
+    if (answer.length === 1 && answer.includes('Email')) {
+      res.redirect('/question_email_to_send_to')
+    }
+
+    if (answer.length === 1 && answer.includes('Text message')) {
+      res.redirect('/question_phone_number_to_send_to')
+    }
+
+    if (answer) {
+      req.session.data.comms_preference_email_sms = true
+      res.redirect('/question_email_to_send_to_duo')
+    }
+  })
+
+  router.post('/question_email_to_send_to_choice', function (req, res) {
+    const emailChoice = req.body.email_choice
+    const emailAndSms = req.session.data.comms_preference_email_sms
+
+    if (!emailChoice && emailAndSms) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('question_email_to_send_to_duo', { error })
+    }
+
+    if (!emailChoice) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('question_email_to_send_to', { error })
+    }
+
+    if (emailChoice === 'No' && emailAndSms) {
+      res.redirect('/question_email_update_duo')
+    }
+
+    if (emailChoice === 'Yes' && emailAndSms) {
+      req.session.data.comms_preference_email_address =
+        req.session.data.question_email_address
+      res.redirect('/question_phone_number_to_send_to_duo')
+    }
+
+    if (emailChoice === 'Yes') {
+      req.session.data.comms_preference_email_address =
+        req.session.data.question_email_address
+      res.redirect('/vetcard_account_summary_extra')
+    }
+
+    if (emailChoice === 'No') {
+      res.redirect('/question_email_update')
+    }
+  })
+
+  router.post('/question_email_update_input', function (req, res) {
+    const emailUpdate = req.body.question_email_address_update
+    const emailAndSms = req.session.data.comms_preference_email_sms
+
+    if (!emailUpdate && emailAndSms) {
+      const errorDuo = { text: 'Enter a valid email address' }
+      return res.render('question_email_update_duo', { errorDuo })
+    }
+
+    if (!emailUpdate) {
+      const error = { text: 'Enter a valid email address' }
+      return res.render('question_email_update', { error })
+    }
+
+    if (emailUpdate && validator.isEmail(emailUpdate) && emailAndSms) {
+      req.session.data.comms_preference_email_address = emailUpdate
+      res.redirect('/question_phone_number_to_send_to_duo')
+    }
+
+    if (emailUpdate && validator.isEmail(emailUpdate)) {
+      req.session.data.comms_preference_email_address = emailUpdate
+      res.redirect('/vetcard_account_summary_extra')
+    } else {
+      const error = { text: 'Enter a valid email address' }
+      return res.render('question_email_update', { error })
+    }
+  })
+
+  router.post('/question_phone_number_to_send_to_choice', function (req, res) {
+    const phoneNumberChoice = req.body.phone_number_choice
+    const emailAndSms = req.session.data.comms_preference_email_sms
+
+    if (!phoneNumberChoice && emailAndSms) {
+      const errorDuo = { text: "Select 'Yes' or 'No'" }
+      return res.render('question_phone_number_to_send_to_duo', { errorDuo })
+    }
+
+    if (!phoneNumberChoice) {
+      const error = { text: "Select 'Yes' or 'No'" }
+      return res.render('question_phone_number_to_send_to', { error })
+    }
+    if (phoneNumberChoice === 'No' && emailAndSms) {
+      res.redirect('/question_phone_number_update_duo')
+    }
+
+    if (phoneNumberChoice === 'Yes') {
+      req.session.data.comms_preference_phone_number = removeStringWhiteSpace(
+        req.session.data.phone_number.toString()
       )
-      .then((response) => console.log(response))
-      .catch((err) => console.error(err.response.data))
+      res.redirect('/vetcard_account_summary_extra')
+    }
 
-    res.redirect('/vetcard_application_complete_card_only')
-  }
+    if (phoneNumberChoice === 'No') {
+      res.redirect('/question_phone_number_update')
+    }
+  })
 
-  if (idChoice === 'Digital card') {
-    notify
-      .sendEmail(
-        process.env.TEST_EMAIL_DIGITAL_ONLY_TEMPLATE,
-        // `emailAddress` here needs to match the name of the form field in
-        // your HTML page
-        emailAddress.toString(),
-        {
-          personalisation,
-          reference: uuidv4()
-        }
-      )
-      .then((response) => console.log(response))
-      .catch((err) => console.error(err.response.data))
+  router.post('/question_phone_number_update_input', function (req, res) {
+    const phoneNumberUpdate = req.body.question_phone_number_update
+    const emailAndSms = req.session.data.comms_preference_email_sms
 
-    res.redirect('/vetcard_application_complete_digital_only')
-  }
+    if (!phoneNumberUpdate && emailAndSms) {
+      console.log('error check 1')
+      const errorDuo = {
+        text: 'Enter a valid UK mobile number, like 077 456 78901'
+      }
+      return res.render('question_phone_number_update_duo', { errorDuo })
+    }
 
-  if (idChoice === 'Physical and Digital') {
-    notify
-      .sendEmail(
-        process.env.TEST_EMAIL_CARD_AND_DIGITAL_TEMPLATE,
-        // `emailAddress` here needs to match the name of the form field in
-        // your HTML page
-        emailAddress.toString(),
-        {
-          personalisation,
-          reference: uuidv4()
-        }
-      )
-      .then((response) => console.log(response))
-      .catch((err) => console.error(err.response.data))
+    if (!phoneNumberUpdate && !emailAndSms) {
+      console.log('error check 2')
+      const error = {
+        text: 'Enter a valid UK mobile number, like 077 456 78901'
+      }
+      return res.render('question_phone_number_update', { error })
+    }
 
-    res.redirect('/vetcard_application_complete_card_digital')
-  }
+    if (phoneNumberUpdate && regexUkMobileNumber(phoneNumberUpdate)) {
+      req.session.data.comms_preference_phone_number =
+        removeStringWhiteSpace(phoneNumberUpdate)
+      res.redirect('/vetcard_account_summary_extra')
+    } else {
+      console.log('error check 3')
+      const error = {
+        text: 'Enter a valid UK mobile number, like 077 456 78901'
+      }
+      return res.render('question_phone_number_update', { error })
+    }
+  })
+
+  router.post('/vetcard_account_summary_choice', function (req, res) {
+    let idChoice = req.session.data.id_choice
+    const fullName = req.session.data.full_name
+    const postalAddress = req.session.data.postal_address
+    const emailAddress = req.session.data.comms_preference_email_address
+    const serviceNumber = req.session.data.question_service_number
+
+    const matchStatus = req.session.data.start_veteran_match_status
+
+    const personalisation = {
+      full_name: fullName.toString(),
+      postal_address: postalAddress.toString(),
+      submission_reference: 'HDJ2123F',
+      service_number: serviceNumber.toString()
+    }
+
+    if (!idChoice) {
+      idChoice = 'Physical card'
+    }
+
+    if (matchStatus === 'Fail') {
+      notify
+        .sendEmail(
+          process.env.TEST_EMAIL_UNHAPPY_PATH_TEMPLATE,
+          // `emailAddress` here needs to match the name of the form field in
+          // your HTML page
+          emailAddress.toString(),
+          {
+            personalisation,
+            reference: uuidv4()
+          }
+        )
+        .then((response) => console.log(response))
+        .catch((err) => console.error(err.response.data))
+
+      res.redirect('/vetcard_match_fail_explanation')
+      return false
+    }
+
+    if (idChoice === 'Physical card') {
+      notify
+        .sendEmail(
+          process.env.TEST_EMAIL_CARD_ONLY_TEMPLATE,
+          // `emailAddress` here needs to match the name of the form field in
+          // your HTML page
+          emailAddress.toString(),
+          {
+            personalisation,
+            reference: uuidv4()
+          }
+        )
+        .then((response) => console.log(response))
+        .catch((err) => console.error(err.response.data))
+
+      res.redirect('/vetcard_application_complete_card_only')
+    }
+
+    if (idChoice === 'Digital card') {
+      notify
+        .sendEmail(
+          process.env.TEST_EMAIL_DIGITAL_ONLY_TEMPLATE,
+          // `emailAddress` here needs to match the name of the form field in
+          // your HTML page
+          emailAddress.toString(),
+          {
+            personalisation,
+            reference: uuidv4()
+          }
+        )
+        .then((response) => console.log(response))
+        .catch((err) => console.error(err.response.data))
+
+      res.redirect('/vetcard_application_complete_digital_only')
+    }
+
+    if (idChoice === 'Physical and Digital') {
+      notify
+        .sendEmail(
+          process.env.TEST_EMAIL_CARD_AND_DIGITAL_TEMPLATE,
+          // `emailAddress` here needs to match the name of the form field in
+          // your HTML page
+          emailAddress.toString(),
+          {
+            personalisation,
+            reference: uuidv4()
+          }
+        )
+        .then((response) => console.log(response))
+        .catch((err) => console.error(err.response.data))
+
+      res.redirect('/vetcard_application_complete_card_digital')
+    }
+  })
 })
-
 module.exports = router

--- a/app/routes.js
+++ b/app/routes.js
@@ -254,8 +254,9 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
     res.locals.DI_names.push( { divider: "or" } )
     res.locals.DI_names.push( { value: "service_name_other", text: "I had a different name" } )
 
-    // Set up session storage for current & previous names
-    // req.session.data.current_DI_name = distinctClaimNames[0]
+    // Set up session storage for current name
+    // This will be printed on the card
+    req.session.data.current_DI_name = distinctClaimNames[0]
 
     // const previousNames = getPreviousNames(distinctClaimNames)
     // req.session.data.previous_DI_names = previousNames
@@ -727,7 +728,7 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
 
   router.post('/vetcard_account_summary_choice', function (req, res) {
     let idChoice = req.session.data.id_choice
-    const fullName = req.session.data.full_name
+    const fullName = req.session.data.name_at_discharge
     const postalAddress = req.session.data.postal_address
     const emailAddress = req.session.data.comms_preference_email_address
     const serviceNumber = req.session.data.question_service_number

--- a/app/routes.js
+++ b/app/routes.js
@@ -210,30 +210,30 @@ router.post('/eligibility_two', function (req, res) {
   }
 })
 
-router.post('/question_email_address_input', function (req, res) {
-  const email = req.session.data.question_email_address
-  const previousApplicationEmail = req.session.data.previous_application_email
+// router.post('/question_email_address_input', function (req, res) {
+//   const email = req.session.data.question_email_address
+//   const previousApplicationEmail = req.session.data.previous_application_email
 
-  if (!email) {
-    const error = { text: 'Enter your email address' }
-    return res.render('question_email_address', { error })
-  }
+//   if (!email) {
+//     const error = { text: 'Enter your email address' }
+//     return res.render('question_email_address', { error })
+//   }
 
-  if (
-    email &&
-    validator.isEmail(email) &&
-    previousApplicationEmail.toString() === email
-  ) {
-    res.redirect('/govuk_previous_application_email')
-  }
+//   if (
+//     email &&
+//     validator.isEmail(email) &&
+//     previousApplicationEmail.toString() === email
+//   ) {
+//     res.redirect('/govuk_previous_application_email')
+//   }
 
-  if (email && validator.isEmail(email)) {
-    res.redirect('/govuk_create_check_email')
-  } else {
-    const error = { text: 'Enter a valid email address' }
-    return res.render('question_email_address', { error })
-  }
-})
+//   if (email && validator.isEmail(email)) {
+//     res.redirect('/govuk_create_check_email')
+//   } else {
+//     const error = { text: 'Enter a valid email address' }
+//     return res.render('question_email_address', { error })
+//   }
+// })
 
 router.post('/question_name_from_identity_claim_choice', function (req, res) {
   const nameChoice = req.session.data.name_at_discharge

--- a/app/routes.js
+++ b/app/routes.js
@@ -567,7 +567,7 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
 
     if (answer === 'No') {
       req.session.data.comms_preference_email_address =
-        req.session.data.question_email_address
+        res.locals.user.email
 
       req.session.data.comms_preference_phone_number = removeStringWhiteSpace(
         req.session.data.phone_number.toString()
@@ -621,13 +621,13 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
 
     if (emailChoice === 'Yes' && emailAndSms) {
       req.session.data.comms_preference_email_address =
-        req.session.data.question_email_address
+        res.locals.user.email
       res.redirect('/question_phone_number_to_send_to_duo')
     }
 
     if (emailChoice === 'Yes') {
       req.session.data.comms_preference_email_address =
-        req.session.data.question_email_address
+        res.locals.user.email
       res.redirect('/vetcard_account_summary_extra')
     }
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -15,11 +15,16 @@ endblock %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Prototype your service using GOV.UK Prototype Kit
-      <span class="govuk-caption-xl">{{releaseVersion}}</span>
-      <span class="govuk-caption-l">Digital prototype sprint 7 v7.2</span>
+      Apply for a Veteran's ID card
+      <span class="govuk-caption-xl">Prototype kit {{releaseVersion}}</span>
     </h1>
     {{releaseVersion | log }}
+
+    {{ govukWarningText({
+      text: "Only choose GOV.UK identity proofing and verification if you have been given the \"synthetic identity\" document.
+            You can't prove your own identity with this service.",
+      iconFallbackText: "Warning"
+    }) }}
 
     <form class="form" action="/start_veteran_apply_choice" method="post">
         {% from "govuk/components/radios/macro.njk" import govukRadios %}
@@ -27,40 +32,20 @@ endblock %}
         {{ govukRadios({
           idPrefix: "start_veteran_match_status",
           name: "start_veteran_match_status",
-          fieldset: {
-            legend: {
-              text: "Please select record match success or fail journey",
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
           items: [
-            {
-              value: "Success",
-              text: "happy path - user automatically matched",
-              checked: checked("start_veteran_match_status", "Success")
-             
-            },
-            {
-              value: "Fail",
-              text: "unhappy path - needs manual verification after",
-              checked: checked("start_veteran_match_status", "Fail")
-             
-            },
             {
               value: "IPV",
               text: "use GOV.UK identity proofing and verification",
               checked: checked("start_veteran_match_status", "IPV")
+            },
+            {
+              value: "skip",
+              text: "skip straight to matching",
+              checked: checked("start_veteran_match_status", "skip")
             }
           ],
           errorMessage: error
         }) }}
-        
-         <h2 class="govuk-heading-s">Please note - when asked for your GOV.UK account</h2>
-         <ul class="govuk-list govuk-list--bullet">
-          <li>enter an email which you have access to in order to receive the summary email on completion of the user journey</li>
-          <li>you can enter any password</li>
-         </ul>
-         
         
        {{ govukButton({
           text: "Apply for a veteran's ID card"

--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -25,6 +25,7 @@
       }) }}
 
       <dl class="govuk-summary-list">
+
         {% for n in user.core_identity.vc.credentialSubject.name %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key govuk-!-width-one-third">

--- a/app/views/question_email_to_send_to.html
+++ b/app/views/question_email_to_send_to.html
@@ -9,19 +9,19 @@ your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'})
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-l">Is this the email address you want to be contacted at?</h1>
-  
-  <p>{{data["question_email_address"]}}</p>
- 
+
+  <p>{{ user.email }}</p>
+
     <form class="form" action="question_email_to_send_to_choice" method="post">
-     
+
       {{
-      govukRadios({ 
-      idPrefix: "email_choice", 
+      govukRadios({
+      idPrefix: "email_choice",
       name: "email_choice",
-      fieldset: { legend: { text: "", 
-      isPageHeading: false, 
+      fieldset: { legend: { text: "",
+      isPageHeading: false,
       classes: "govuk-fieldset__legend--l"
-      } }, 
+      } },
       items: [
           {
             value: "Yes",
@@ -33,7 +33,7 @@ your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'})
             text: "No",
             checked: checked("email_choice", "No")
           }
-        ], 
+        ],
       errorMessage: error }) }}
 
       <button class="govuk-button" id="btn" data-module="govuk-button">

--- a/app/views/question_name_from_identity_claim.html
+++ b/app/views/question_name_from_identity_claim.html
@@ -8,30 +8,16 @@ your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'})
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-  <h1 class="govuk-heading-l">Was "{{data["current_DI_name"]}}" the name you were using when you left the armed forces?</h1>
- 
     <form class="form" action="question_name_from_identity_claim_choice" method="post">
-      
       {{
-      govukRadios({ 
-      idPrefix: "name_at_discharge", 
+      govukRadios({
+      idPrefix: "name_at_discharge",
       name: "name_at_discharge",
-      fieldset: { legend: { text: "", 
-      isPageHeading: false, 
+      fieldset: { legend: { text: "What was your name when you left the armed forces?",
+      isPageHeading: false,
       classes: "govuk-fieldset__legend--l"
-      } }, 
-      items: [
-          {
-            value: "Yes",
-            text: "Yes",
-            checked: checked("name_at_discharge", "Yes")
-          },
-          {
-            value: "No",
-            text: "No",
-            checked: checked("name_at_discharge", "No")
-          }
-        ], 
+      } },
+      items: DI_names,
       errorMessage: error }) }}
 
       <button class="govuk-button" id="btn" data-module="govuk-button">

--- a/app/views/vetcard_account_summary_extra.html
+++ b/app/views/vetcard_account_summary_extra.html
@@ -42,7 +42,7 @@ tag: { text: "alpha" }, html: 'This is a new service – your
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Email</dt>
           <dd class="govuk-summary-list__value">
-            <p class="govuk-body">{{data["question_email_address"]}}</p>
+            <p class="govuk-body">{{ user.email }}</p>
           </dd>
         </div>
         <div class="govuk-summary-list__row">

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "nunjucks": "^3.2.1",
         "openid-client": "^5.2.1",
         "passport": "^0.6.0",
+        "passport-local": "^1.0.0",
         "portscanner": "^2.1.1",
         "require-dir": "^1.0.0",
         "rsa-pem-to-jwk": "^1.1.3",
@@ -2808,6 +2809,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/passport-strategy": {
@@ -6039,6 +6051,14 @@
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
         "utils-merge": "^1.0.1"
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
+      "requires": {
+        "passport-strategy": "1.x.x"
       }
     },
     "passport-strategy": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nunjucks": "^3.2.1",
     "openid-client": "^5.2.1",
     "passport": "^0.6.0",
+    "passport-local": "^1.0.0",
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",
     "rsa-pem-to-jwk": "^1.1.3",


### PR DESCRIPTION
The userdata we get back from the IdP (or local fake) weren't persisting across page views.  This change ensures all the routes are "inside" the node-openid-client callback sequence, and copies the passport.user object to res.locals.user for convenience.

(Some of this is hackery of the worst sort, and I wouldn't do this in production)