### PR TITLE
Remove govuk_frontend_toolkit as it's superseded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "express-session": "^1.17.3",
         "fancy-log": "^2.0.0",
         "fs-extra": "^10.0.1",
-        "govuk_frontend_toolkit": "^7.5.0",
         "govuk_template_jinja": "^0.26.0",
         "govuk-elements-sass": "^3.1.3",
         "govuk-frontend": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "express-session": "^1.17.3",
     "fancy-log": "^2.0.0",
     "fs-extra": "^10.0.1",
-    "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.26.0",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.3.1",


### PR DESCRIPTION
govuk_frontend_toolkit is only required for v6 prototype backwards compatibility, and it's generating spurious Dependabot alerts