### PR TITLE
Address the veteran by their current name in the confirmation email

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -636,7 +636,7 @@ Issuer.discover(process.env.ISSUER_BASE_URL).then(issuer => {
 
   router.post('/vetcard_account_summary_choice', function (req, res) {
     let idChoice = req.session.data.id_choice
-    const fullName = req.session.data.name_at_discharge
+    const fullName = req.session.data.current_DI_name
     const postalAddress = req.session.data.postal_address
     const emailAddress = req.session.data.comms_preference_email_address
     const serviceNumber = req.session.data.question_service_number


### PR DESCRIPTION
The confirmation email was addressing the veteran by their "name at discharge" which would be surprising and worrying.